### PR TITLE
fix: remove safe variable from webpack plugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -118,8 +118,8 @@ module.exports = {
       patterns: [{ from: 'public/runtime-env.js', to: 'runtime-env.js' }],
     }),
     new DotenvPlugin({
-      safe: true, // load '.env.example' to verify the '.env' variables are all set. Can also be a string to a different file.
-      systemvars: true, // load all the predefined 'process.env' variables which will trump anything local per dotenv specs.
+      // load all the predefined 'process.env' variables which will trump anything local per dotenv specs.
+      systemvars: true,
     }),
     new NodePolyfillPlugin(),
     new ModuleFederationPlugin({


### PR DESCRIPTION
No longer going to use this `feat/bizops` branch. Will delete soon.