### PR TITLE
Use correct sign when comparing balance

### DIFF
--- a/helm/finance-portal-v2-ui/Chart.yaml
+++ b/helm/finance-portal-v2-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "v3.0.0"
+appVersion: "v3.0.1"
 description: Mojaloop Finance Portal UI v2
 name: finance-portal-v2-ui
-version: 3.0.0
+version: 3.0.1

--- a/helm/finance-portal-v2-ui/values.yaml
+++ b/helm/finance-portal-v2-ui/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/mojaloop/finance-portal-v2-ui
-  tag: v3.0.0
+  tag: v3.0.1
   pullPolicy: IfNotPresent
 
 imagePullCredentials:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finance-portal-v2-ui",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/App/Settlements/SettlementFinalizingModal/connectors.ts
+++ b/src/App/Settlements/SettlementFinalizingModal/connectors.ts
@@ -45,7 +45,11 @@ const dispatchProps = (dispatch: Dispatch) => ({
     dispatch(actions.setSettlementFinalizingInProgress(true));
     dispatch(actions.finalizeSettlement(settlement));
   },
-  onSelectSettlementReport: (report: SettlementReport) => dispatch(actions.setSettlementReport(report || null)),
+  onSelectSettlementReport: (report: SettlementReport) => {
+    dispatch(actions.setSettlementReportValidationErrors(null));
+    dispatch(actions.setSettlementReportValidationWarnings(null));
+    dispatch(actions.setSettlementReport(report || null));
+  },
   onSettlementReportProcessingError: (err: string) => dispatch(actions.setSettlementReportError(err)),
   onSetFundsInOutChange: (e: React.ChangeEvent<HTMLInputElement>) => {
     dispatch(actions.setFinalizeProcessFundsInOut(e.target.checked));

--- a/src/App/Settlements/SettlementFinalizingModal/index.tsx
+++ b/src/App/Settlements/SettlementFinalizingModal/index.tsx
@@ -268,6 +268,7 @@ const SettlementFinalizingModal: FC<ConnectorProps> = ({
           }
         }}
       />
+      {settlementReportValidationErrors?.length === 0 ? <>&nbsp;✅</> : <></>}
       <br />
       <Button
         pending={settlementFinalizingInProgress}

--- a/src/App/Settlements/SettlementFinalizingModal/index.tsx
+++ b/src/App/Settlements/SettlementFinalizingModal/index.tsx
@@ -312,24 +312,24 @@ const SettlementFinalizingModal: FC<ConnectorProps> = ({
     >
       {content}
       {settlementReportValidationWarnings?.length &&
-        settlementReportValidationWarnings?.length > 0 &&
-        settlementReportValidationErrors?.length === 0 && (
-          <Modal title="Settlement Report Validation Warnings" width="1200px" onClose={onClearSettlementReportWarnings}>
-            <ErrorBox>
-              <div>
-                <h3>Warning: the following was found in the settlement finalization report:</h3>
-                <hr />
-                {settlementReportValidationWarnings?.map((e: SettlementReportValidation) => (
-                  <div key={hash(e)}>{displaySettlementReportValidation(e)}</div>
-                ))}
-                <hr />
-                <h3>
-                  These are not fatal errors. After closing this dialog, it will be possible to process the report.
-                </h3>
-              </div>
-            </ErrorBox>
-          </Modal>
-        )}
+      settlementReportValidationWarnings?.length > 0 &&
+      settlementReportValidationErrors?.length === 0 ? (
+        <Modal title="Settlement Report Validation Warnings" width="1200px" onClose={onClearSettlementReportWarnings}>
+          <ErrorBox>
+            <div>
+              <h3>Warning: the following was found in the settlement finalization report:</h3>
+              <hr />
+              {settlementReportValidationWarnings?.map((e: SettlementReportValidation) => (
+                <div key={hash(e)}>{displaySettlementReportValidation(e)}</div>
+              ))}
+              <hr />
+              <h3>These are not fatal errors. After closing this dialog, it will be possible to process the report.</h3>
+            </div>
+          </ErrorBox>
+        </Modal>
+      ) : (
+        <></>
+      )}
     </Modal>
   );
 };

--- a/src/App/Settlements/helpers.ts
+++ b/src/App/Settlements/helpers.ts
@@ -464,12 +464,12 @@ export function generateSettlementReportValidationDetail(val: SettlementReportVa
       );
     case SettlementReportValidationKind.BalanceNotAsExpected:
       return (
-        `Row ${val.data.entry.row.rowNumber} of the report has a balance of ` +
+        `Row ${val.data.entry.row.rowNumber} of the report indicates a balance of ` +
         `${val.data.reportBalance} and a transfer amount of ${val.data.transferAmount}. ` +
         `${val.data.entry.participant.name} presently has a liquidity account balance of ` +
-        `${val.data.account.value}. Applying the transfer to this balance results in an ` +
-        `expected balance of ${val.data.expectedBalance}. The balance in the report is ` +
-        `${val.data.reportBalance}.`
+        `${Math.abs(val.data.account.value)}. Applying the transfer to this balance results in ` +
+        `an expected balance of ${val.data.expectedBalance}, not ${val.data.reportBalance} as ` +
+        `per the report.`
       );
     case SettlementReportValidationKind.AccountsNotPresentInReport: {
       // prettier-ignore
@@ -683,7 +683,9 @@ export const validationFunctions = {
       })
       .filter((e): e is { entry: SettlementReportEntry; settlementAccount: AccountWithPosition } => e !== undefined)
       .forEach(({ entry, settlementAccount }) => {
-        const expectedBalance = settlementAccount.value + entry.transferAmount;
+        // The switch uses negative numeric values to represent credit. The switch does not support
+        // debit settlement account balances. Therefore we use Math.abs here.
+        const expectedBalance = Math.abs(settlementAccount.value) + entry.transferAmount;
         const reportBalance = entry.balance;
         if (!equal(expectedBalance, reportBalance)) {
           result.add({


### PR DESCRIPTION
Also:
* Use correct sign when comparing balance and improve message to user
* Reset validation results when selecting a different report
* Display a tick for a validated report
* Don't display 0 when there are no settlement finalization report warnings